### PR TITLE
fix: Courses page is now responsive.

### DIFF
--- a/courses.html
+++ b/courses.html
@@ -17,9 +17,8 @@
     <!-- Swiper js -->
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/swiper@9/swiper-bundle.min.css"/>
 
-
-    <link rel="stylesheet" href="./CSS/style.css">
     <link rel="stylesheet" href="./CSS/courses.css">
+    <link rel="stylesheet" href="./CSS/style.css">
 </head>
 <body>
     <nav>


### PR DESCRIPTION
This PR closes #1 

I have just reordered the styles files to work fine and also responsive.

Merge the PR,

BEFORE: It was not responsive: 
![BEFORE](https://github.com/choyon-ugv/IQAC-Website/assets/46226834/23ccd361-3cd5-4b30-9353-98ef5364738b)

AFTER: The PR fixes the issue. 
![AFTER](https://github.com/choyon-ugv/IQAC-Website/assets/46226834/2e021326-68b8-4e4e-b2ed-3030522cb252)
